### PR TITLE
adds basic customization of site name via APP_NAME environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="aptalca"
 
 # environment settings
-ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2
+ENV S6_BEHAVIOUR_IF_STAGE2_FAILS=2 \
+	APP_NAME=Heimdall
 
 # install packages
 RUN \


### PR DESCRIPTION
I use multiple instances of Heimdall in different domains, but because I cannot change the app name, the cannot be distinguished by name when open in inactive browser tabs.  They're all named "Heimdall" and have identical favicons.  This at least would allow me and others to name their page(s)
