### PR TITLE
Hide nginx's version number

### DIFF
--- a/root/defaults/nginx.conf
+++ b/root/defaults/nginx.conf
@@ -19,7 +19,7 @@ http {
 	tcp_nodelay on;
 	keepalive_timeout 65;
 	types_hash_max_size 2048;
-	# server_tokens off;
+	server_tokens off;
 
 	# server_names_hash_bucket_size 64;
 	# server_name_in_redirect off;


### PR DESCRIPTION
Hide nginx's version number from the server header response.

I would also be a good idea to do the same for PHP
```
expose_php = Off
```