### PR TITLE
sets /config/www/.env vars from passed env vars. closes #35

### DIFF
--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -27,6 +27,50 @@ done
 # set queue driver to database
 sed -i 's/QUEUE_DRIVER=sync/QUEUE_DRIVER=database/' /config/www/.env
 
+# set .env vars from environment, if set
+[[ ! -z $APP_NAME ]] && \
+  sed -i 's/APP_NAME=.\+/APP_NAME='"$APP_NAME"'/' /config/www/.env
+[[ ! -z $APP_DEBUG ]] && \
+  sed -i 's/APP_DEBUG=.\+/APP_DEBUG='"$APP_DEBUG"'/' /config/www/.env
+[[ ! -z $APP_LOG_LEVEL ]] && \
+  sed -i 's/APP_LOG_LEVEL=.\+/APP_LOG_LEVEL='"$APP_LOG_LEVEL"'/' /config/www/.env
+[[ ! -z $APP_URL ]] && \
+  sed -i 's%APP_URL=.\+%APP_URL='"$APP_URL"'%' /config/www/.env
+[[ ! -z $DB_CONNECTION ]] && \
+  sed -i 's/DB_CONNECTION=.\+/DB_CONNECTION='"$DB_CONNECTION"'/' /config/www/.env
+[[ ! -z $DB_DATABASE ]] && \
+  sed -i 's/DB_DATABASE=.\+/DB_DATABASE='"$DB_DATABASE"'/' /config/www/.env
+[[ ! -z $REDIS_HOST ]] && \
+  sed -i 's/REDIS_HOST=.\+/REDIS_HOST='"$REDIS_HOST"'/' /config/www/.env
+[[ ! -z $REDIS_PASSWORD ]] && \
+  sed -i 's/REDIS_PASSWORD=.\+/REDIS_PASSWORD='"$REDIS_PASSWORD"'/' /config/www/.env
+[[ ! -z $REDIS_PORT ]] && \
+  sed -i 's/REDIS_PORT=.\+/REDIS_PORT='"$REDIS_PORT"'/' /config/www/.env
+[[ ! -z $MAIL_DRIVER ]] && \
+  sed -i 's/MAIL_DRIVER=.\+/MAIL_DRIVER='"$MAIL_DRIVER"'/' /config/www/.env
+[[ ! -z $MAIL_HOST ]] && \
+  sed -i 's/MAIL_HOST=.\+/MAIL_HOST='"$MAIL_HOST"'/' /config/www/.env
+[[ ! -z $MAIL_PORT ]] && \
+  sed -i 's/MAIL_PORT=.\+/MAIL_PORT='"$MAIL_PORT"'/' /config/www/.env
+[[ ! -z $MAIL_USERNAME ]] && \
+  sed -i 's/MAIL_USERNAME=.\+/MAIL_USERNAME='"$MAIL_USERNAME"'/' /config/www/.env
+[[ ! -z $MAIL_PASSWORD ]] && \
+  sed -i 's/MAIL_PASSWORD=.\+/MAIL_PASSWORD='"$MAIL_PASSWORD"'/' /config/www/.env
+[[ ! -z $MAIL_ENCRYPTION ]] && \
+  sed -i 's/MAIL_ENCRYPTION=.\+/MAIL_ENCRYPTION='"$MAIL_ENCRYPTION"'/' /config/www/.env
+[[ ! -z $PUSHER_APP_ID ]] && \
+  sed -i 's/PUSHER_APP_ID=.\+/PUSHER_APP_ID='"$PUSHER_APP_ID"'/' /config/www/.env
+[[ ! -z $PUSHER_APP_KEY ]] && \
+  sed -i 's%PUSHER_APP_KEY=.\+%PUSHER_APP_KEY='"$PUSHER_APP_KEY"'%' /config/www/.env
+[[ ! -z $PUSHER_APP_SECRET ]] && \
+  sed -i 's/PUSHER_APP_SECRET=.\+/PUSHER_APP_SECRET='"$PUSHER_APP_SECRET"'/' /config/www/.env
+[[ ! -z $PUSHER_APP_CLUSTER ]] && \
+  sed -i 's/PUSHER_APP_CLUSTER=.\+/PUSHER_APP_CLUSTER='"$PUSHER_APP_CLUSTER"'/' /config/www/.env
+[[ ! -z $FORCE_HTTPS ]] && \
+  (grep -q -e "FORCE_HTTPS=" /config/www/.env || \
+    cat "FORCE_HTTPS=$FORCE_HTTPS" >> /config/www/.env) && \
+  sed -i 's/FORCE_HTTPS=.\+/FORCE_HTTPS='"$FORCE_HTTPS"'/' /config/www/.env
+
 # permissions
 chown -R abc:abc \
 	/config \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

This actually allows setting of variables in /config/www/.env via passed environment variables, allowing you to deploy Heimdall already-configured (e.g. as part of a docker-compose stack) rather than retroactively configuring it manually and restarting the container.  It is scripted such that /config/www/.env will ONLY be modified if the corresponding environment variable is set inside the container.  Re-configuring is possible by passing a new value for the corresponding variable when re-creating the container.  There is no need to delete /config/www/.env to reconfigure in this way.  Manual config of the file is still possible by setting these environment variables.  These changes DO NOT alter or affect the generated value of APP_KEY in anyway.  I have made every attempt to conform to your scripting conventions.
