### PR TITLE
Use long options to docker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ Here are some example snippets to help you get started creating a container.
 ```
 docker create \
   --name=heimdall \
-  -e PUID=1000 \
-  -e PGID=1000 \
-  -e TZ=Europe/London \
-  -p 80:80 \
-  -p 443:443 \
-  -v </path/to/appdata/config>:/config \
+  --env PUID=1000 \
+  --env PGID=1000 \
+  --env TZ=Europe/London \
+  --publish 80:80 \
+  --publish 443:443 \
+  --volume </path/to/appdata/config>:/config \
   --restart unless-stopped \
   linuxserver/heimdall
 ```


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
Use long docker options instead of single-character shorthand versions.

## Benefits of this PR and context:
When demonstrating example commands to run (which will likely be copy/pasted into a script or a shell directly), it's much more instructive to use the long options. Even if a user isn't intimately familiar with docker, using the long options give them a chance to see what each one is doing rather than being a more impenetrable series of cryptic symbols.

## How Has This Been Tested?
I've modified my own scripts to use this version and proven that it works.