### PR TITLE
added php7-curl for http_proxy ENV support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN \
  apk add --no-cache --upgrade \
 	curl \
 	php7-ctype \
+	php7-curl \
 	php7-pdo_pgsql \
 	php7-pdo_sqlite \
 	php7-tokenizer \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,6 +15,7 @@ RUN \
  apk add --no-cache --upgrade \
 	curl \
 	php7-ctype \
+	php7-curl \
 	php7-pdo_pgsql \
 	php7-pdo_sqlite \
 	php7-tokenizer \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -15,6 +15,7 @@ RUN \
  apk add --no-cache --upgrade \
 	curl \
 	php7-ctype \
+	php7-curl \
 	php7-pdo_pgsql \
 	php7-pdo_sqlite \
 	php7-tokenizer \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -49,6 +49,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "17.08.20:", desc: "Add php7-curl." }
   - { date: "01.06.20:", desc: "Rebasing to alpine 3.12." }
   - { date: "17.01.20:", desc: "Use nginx from baseimage." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }


### PR DESCRIPTION
## Description:
Added php7-curl package 

## Benefits of this PR and context:
Without this package, the http_proxy environment variables are not working inside the container. 
In an restricted env with an outgoing proxy server this is needed.
closes #65 

## How Has This Been Tested?
added package in container, restart

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
