### PR TITLE
Allow overriding APP_URL from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/London
+      # - APP_URL=https://host.domain:1234/heimdall/
     volumes:
       - </path/to/appdata/config>:/config
     ports:
@@ -129,6 +130,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London |
+| `-e APP_URL=https://host.domain:1234/heimdall/` | Optionally specify a fully-qualified APP_URL which will override the detected default  |
 | `-v /config` | Contains all relevant configuration files. |
 
 ## Environment variables from files (Docker secrets)

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -36,6 +36,7 @@ param_ports:
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London"}
+  - { env_var: "APP_URL", env_value: "https://<host>:<port>/<path>/", desc: "Optionally specify the full URL which will override the detected default"}
 
 # application setup block
 app_setup_block_enabled: true
@@ -49,6 +50,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "10.01.22:", desc: "Add APP_URL environment variable." }
   - { date: "10.02.21:", desc: "Revert to alpine 3.12 as php 7.4 broke laravel." }
   - { date: "10.02.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "17.08.20:", desc: "Add php7-curl." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -36,6 +36,7 @@ param_ports:
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London"}
+opt_param_env_vars:
   - { env_var: "APP_URL", env_value: "https://<host>:<port>/<path>/", desc: "Optionally specify the full URL which will override the detected default"}
 
 # application setup block

--- a/root/etc/cont-init.d/50-config
+++ b/root/etc/cont-init.d/50-config
@@ -45,6 +45,10 @@ done
   php /var/www/localhost/heimdall/artisan key:generate
 # set queue driver to database
 sed -i 's/QUEUE_DRIVER=sync/QUEUE_DRIVER=database/' /config/www/.env
+if [ ! -z "$APP_URL" ]; then
+  APP_URL_ESCAPED=$(printf '%s\n' "$APP_URL" | sed -e 's/[\/&]/\\&/g')
+  sed -i "s/APP_URL=.*/APP_URL=$APP_URL_ESCAPED/g" /config/www/.env
+fi
 
 # permissions
 echo "Setting permissions"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-heimdall/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Allow overriding APP_URL from environment.
This is necessary if using https://host.domain:1234/heimdall or a similar URL behind a reverse proxy.  Otherwise everything looks broken as no subpaths load properly.
Changes simply check environment variable and if so change the .env file accordingly.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This closes issue #80 and permits the server to operate behind a reverse proxy such as caddy or traefik at a subpath instead of at a root of a hostname

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running own system with this change, and these relevant configuration changes.
```
    environment:
      - 'APP_URL=https://my.hostname:443/heimdall/'
    labels:
      - 'traefik.enable=true'
      - 'traefik.http.routers.heimdall.entrypoints=web-secure'
      - 'traefik.http.routers.heimdall.tls.certResolver=leresolver'
      - 'traefik.http.routers.heimdall.rule=Host(`my.hostname`) && PathPrefix(`/heimdall`)'
      - "traefik.http.middlewares.stripprefix.stripprefixregex.regex=\/([^\/])+"
      - "traefik.http.routers.heimdall.middlewares=stripprefix@docker"
      - 'traefik.http.services.heimdall.loadbalancer.server.port=80'
```
Note that using just a subpath (/heimdall) doesn't work for an APP_URL.  Only the full URL should be used.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
Issue #80 
